### PR TITLE
Don't use empty string as Nightscout secret, use nil

### DIFF
--- a/FreeAPS/Sources/Services/Network/NightscoutAPI.swift
+++ b/FreeAPS/Sources/Services/Network/NightscoutAPI.swift
@@ -5,7 +5,7 @@ import Foundation
 class NightscoutAPI {
     init(url: URL, secret: String? = nil) {
         self.url = url
-        self.secret = secret
+        self.secret = secret?.nonEmpty
     }
 
     private enum Config {


### PR DESCRIPTION
Don't use empty string as Nightscout secret, use nil