### PR TITLE
Now "%d min ago" can be localized.

### DIFF
--- a/FreeAPS/Sources/Modules/Home/View/Header/LoopView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Header/LoopView.swift
@@ -35,7 +35,7 @@ struct LoopView: View {
             if isLooping {
                 Text("looping").font(.caption2)
             } else if actualSuggestion?.timestamp != nil {
-                Text(timeString).font(.caption2)
+                Text("\(timeInt, specifier: "%d") min ago").font(.caption2)
                     .foregroundColor(.secondary)
             } else {
                 Text("--").font(.caption2).foregroundColor(.secondary)
@@ -43,12 +43,12 @@ struct LoopView: View {
         }
     }
 
-    private var timeString: String {
+    private var timeInt: Int {
         let minAgo = Int((timerDate.timeIntervalSince(lastLoopDate) - Config.lag) / 60) + 1
         if minAgo > 1440 {
-            return "--"
+            return 999
         }
-        return "\(minAgo) min ago"
+        return minAgo
     }
 
     private var color: Color {


### PR DESCRIPTION
Changed to a string literal instead of a string variable. Tested with Swedish. Works now.  