### PR TITLE
Localize "min ago"

### DIFF
--- a/FreeAPS/Sources/Modules/Home/View/Header/LoopView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Header/LoopView.swift
@@ -48,7 +48,7 @@ struct LoopView: View {
         if minAgo > 1440 {
             return "--"
         }
-        return "\(minAgo) min ago"
+        return "\(minAgo) " + NSLocalizedString("min ago", comment: "Minutes ago since last loop")
     }
 
     private var color: Color {


### PR DESCRIPTION
since last loop. 2nd attempt. First PR had a different fix to "min ago" not localized, but since it hasn't been merged/accepted yet, I'll make a new suggestion here with fewer code changes. 