### PR TITLE
New Link-translation fixes for rileylink_ios dependency

### DIFF
--- a/Dependencies/rileylink_ios/RileyLinkKitUI/Base.lproj/Localizable.strings
+++ b/Dependencies/rileylink_ios/RileyLinkKitUI/Base.lproj/Localizable.strings
@@ -37,5 +37,68 @@
 /* The title of the cell showing BLE signal strength (RSSI) */
 "Signal Strength" = "Signal Strength";
 
+/* The header of the cells showing connection monitoring */
+"Connection Monitoring" = "Connection Monitoring";
+
 /* The title of the cell showing uptime */
 "Uptime" = "Uptime";
+
+/* The title of the cell showing battery level */
+"Battery level" = "Battery level";
+
+/* The title of the cell showing Voltage */
+"Voltage" = "Voltage";
+
+/* "The title of the section for alerts" */
+"Alert" = "Alert";
+
+/* The title of the cell showing Low Battery Alert */
+"Low Battery Alert" = "Low Battery Alert";
+
+/* Header of list showing battery level alert options */
+"Battery level Alert" = "Battery level Alert";
+
+/* Battery level alert OFF in list of options */
+"OFF" = "OFF";
+
+/* The title of the command to update diagnostic LEDs */
+"Diagnostic LEDs" = "Diagnostic LEDs";
+
+/* The title of the command to fetch RileyLink statistics */
+"Get RileyLink Statistics" = "Get RileyLink Statistics";
+
+/* The title of the command to invert BLE connection LED logic */
+"Invert LED Logic" = "Invert LED Logic";
+
+/* The header of the cells showing test commands */
+"Test Commands" = "Test Commands";
+
+/* The title of the cell showing Lighten Yellow LED */
+"Lighten Yellow LED" = "Lighten Yellow LED";
+
+/* The title of the cell showing Lighten Yellow LED */
+"Lighten Red LED" = "Lighten Red LED";
+
+/* The title of the cell showing Test Vibration */
+"Test Vibration" = "Test Vibration";
+
+/* The title of the cell for sounding device finding piezo */
+"Find Device" = "Find Device";
+
+/* The title of the cell for connection LED */
+"Connection LED" = "Connection LED";
+
+/* The title of the cell for connection vibration */
+"Connection Vibration" = "Connection Vibration";
+
+/* Detail text when battery alert disabled. */
+"Off" = "Off";
+
+/* Text indicating LED Mode is on */
+"On" = "On";
+
+/* Text indicating LED Mode is off */
+"Off" = "Off";
+
+/* Text indicating LED Mode is auto */
+"Auto" = "Auto";

--- a/Dependencies/rileylink_ios/RileyLinkKitUI/RileyLinkDeviceTableViewController.swift
+++ b/Dependencies/rileylink_ios/RileyLinkKitUI/RileyLinkDeviceTableViewController.swift
@@ -584,17 +584,17 @@ public class RileyLinkDeviceTableViewController: UITableViewController {
                 cell.textLabel?.text = LocalizedString("Frequency", comment: "The title of the cell showing current rileylink frequency")
                 cell.setDetailFrequency(frequency, formatter: frequencyFormatter)
             case .battery:
-                cell.textLabel?.text = NSLocalizedString("Battery level", comment: "The title of the cell showing battery level")
+                cell.textLabel?.text = LocalizedString("Battery level", comment: "The title of the cell showing battery level")
                 cell.setDetailBatteryLevel(battery)
             case .voltage:
-                cell.textLabel?.text = NSLocalizedString("Voltage", comment: "The title of the cell showing ORL")
+                cell.textLabel?.text = LocalizedString("Voltage", comment: "The title of the cell showing ORL")
                 cell.setVoltage(voltage)
             }
         case .alert:
             switch AlertRow(rawValue: indexPath.row)! {
             case .battery:
                 cell.accessoryType = .disclosureIndicator
-                cell.textLabel?.text = NSLocalizedString("Low Battery Alert", comment: "The title of the cell showing battery level")
+                cell.textLabel?.text = LocalizedString("Low Battery Alert", comment: "The title of the cell showing battery level")
                 cell.setBatteryAlert(batteryAlertLevel, formatter: integerFormatter)
             }
         case .rileyLinkCommands:
@@ -622,19 +622,19 @@ public class RileyLinkDeviceTableViewController: UITableViewController {
                 switchView.isHidden = false
                 cell.accessoryType = .none
                 switchView.isOn = yellowOn
-                cell.textLabel?.text = NSLocalizedString("Lighten Yellow LED", comment: "The title of the cell showing Lighten Yellow LED")
+                cell.textLabel?.text = LocalizedString("Lighten Yellow LED", comment: "The title of the cell showing Lighten Yellow LED")
             case .red:
                 switchView.isHidden = false
                 cell.accessoryType = .none
                 switchView.isOn = redOn
-                cell.textLabel?.text = NSLocalizedString("Lighten Red LED", comment: "The title of the cell showing Lighten Red LED")
+                cell.textLabel?.text = LocalizedString("Lighten Red LED", comment: "The title of the cell showing Lighten Red LED")
             case .shake:
                 switchView.isHidden = false
                 switchView.isOn = shakeOn
                 cell.accessoryType = .none
-                cell.textLabel?.text = NSLocalizedString("Test Vibration", comment: "The title of the cell showing Test Vibration")
+                cell.textLabel?.text = LocalizedString("Test Vibration", comment: "The title of the cell showing Test Vibration")
             case .findDevice:
-                cell.textLabel?.text = NSLocalizedString("Find Device", comment: "The title of the cell for sounding device finding piezo")
+                cell.textLabel?.text = LocalizedString("Find Device", comment: "The title of the cell for sounding device finding piezo")
                 cell.detailTextLabel?.text = nil
             }
         case .configureCommand:
@@ -643,12 +643,12 @@ public class RileyLinkDeviceTableViewController: UITableViewController {
                 switchView.isHidden = false
                 switchView.isOn = ledOn
                 cell.accessoryType = .none
-                cell.textLabel?.text = NSLocalizedString("Connection LED", comment: "The title of the cell for connection LED")
+                cell.textLabel?.text = LocalizedString("Connection LED", comment: "The title of the cell for connection LED")
             case .connectionVibrate:
                 switchView.isHidden = false
                 switchView.isOn = vibrationOn
                 cell.accessoryType = .none
-                cell.textLabel?.text = NSLocalizedString("Connection Vibration", comment: "The title of the cell for connection vibration")
+                cell.textLabel?.text = LocalizedString("Connection Vibration", comment: "The title of the cell for connection vibration")
             }
         }
 
@@ -779,8 +779,8 @@ public class RileyLinkDeviceTableViewController: UITableViewController {
         case .alert:
             switch AlertRow(rawValue: indexPath.row)! {
             case .battery:
-                let alert = UIAlertController.init(title: "Battery level Alert", message: nil, preferredStyle: .actionSheet)
-                let action = UIAlertAction.init(title: "OFF", style: .default) { _ in
+                let alert = UIAlertController.init(title: LocalizedString("Battery level Alert", comment: "Header of list showing battery level alert options"), message: nil, preferredStyle: .actionSheet)
+                let action = UIAlertAction.init(title: LocalizedString("OFF", comment: "Battery level alert OFF in list of options"), style: .default) { _ in
                     self.batteryAlertLevel = nil
                     self.tableView.reloadData()
                 }
@@ -893,6 +893,6 @@ private extension UITableViewCell {
     }
     
     func setBatteryAlert(_ level: Int?, formatter: NumberFormatter) {
-        detailTextLabel?.text = formatter.percentString(from: level) ?? NSLocalizedString("Off", comment: "Detail text when battery alert disabled.")
+        detailTextLabel?.text = formatter.percentString(from: level) ?? LocalizedString("Off", comment: "Detail text when battery alert disabled.")
     }
 }

--- a/Dependencies/rileylink_ios/RileyLinkKitUI/sv.lproj/Localizable.strings
+++ b/Dependencies/rileylink_ios/RileyLinkKitUI/sv.lproj/Localizable.strings
@@ -37,5 +37,69 @@
 /* The title of the cell showing BLE signal strength (RSSI) */
 "Signal Strength" = "Signalstyrka";
 
+/* The header of the cells showing connection monitoring */
+"Connection Monitoring" = "Anslutningsstatus";
+
 /* The title of the cell showing uptime */
 "Uptime" = "Körs sedan";
+
+/* The title of the cell showing battery level */
+"Battery level" = "Batterinivå";
+
+/* The title of the cell showing Voltage */
+"Voltage" = "Spänning (V)";
+
+//* "The title of the section for alerts" */
+"Alert" = "Varning";
+
+/* The title of the cell showing Low Battery Alert */
+"Low Battery Alert" = "Låg batterinivå";
+
+/* Header of list showing battery level alert options */
+"Battery level Alert" = "Varning batterinivå";
+
+/* Battery level alert OFF in list of options */
+"OFF" = "AV";
+
+/* The title of the command to update diagnostic LEDs */
+"Diagnostic LEDs" = "Diagnostiska LED";
+
+/* The title of the command to fetch RileyLink statistics */
+"Get RileyLink Statistics" = "Hämta RileyLink-statistik";
+
+/* The title of the command to invert BLE connection LED logic */
+"Invert LED Logic" = "Invertera LED-Logik";
+
+/* The header of the cells showing test commands */
+"Test Commands" = "Testkommandon";
+
+/* The title of the cell showing Lighten Yellow LED */
+"Lighten Yellow LED" = "Ljusare gul LED";
+
+/* The title of the cell showing Lighten Yellow LED */
+"Lighten Red LED" = "Ljusare röd LED";
+
+/* The title of the cell showing Test Vibration */
+"Test Vibration" = "Testa vibration";
+
+/* The title of the cell for sounding device finding piezo */
+"Find Device" = "Hitta enhet";
+
+/* The title of the cell for connection LED */
+"Connection LED" = "Anslutnings-LED";
+
+/* The title of the cell for connection vibration */
+"Connection Vibration" = "Anslutningsvibration";
+
+/* Detail text when battery alert disabled. */
+"Off" = "Av";
+
+/* Text indicating LED Mode is on */
+"On" = "På";
+
+/* Text indicating LED Mode is off */
+"Off" = "Av";
+
+/* Text indicating LED Mode is auto */
+"Auto" = "Auto";
+


### PR DESCRIPTION
Mixing of both NSLocalizedString and LocalizedString made half of translations not working.
Adding necessary source strings to Base.lproj
Adding Swedish translations to new link-strings