### PR TITLE
Improved PodCommsError fault checking during pod setup

### DIFF
--- a/Dependencies/rileylink_ios/OmniKitUI/ViewControllers/InsertCannulaSetupViewController.swift
+++ b/Dependencies/rileylink_ios/OmniKitUI/ViewControllers/InsertCannulaSetupViewController.swift
@@ -118,14 +118,19 @@ class InsertCannulaSetupViewController: SetupTableViewController {
             }
             loadingText = errorText
             
-            var podCommsError: PodCommsError? = nil
+            let podCommsError: PodCommsError?
             if let pumpManagerError = lastError as? PumpManagerError {
                 switch pumpManagerError {
-                case .communication(let error):
+                // Check for a wrapped PodCommsError in the possible PumpManagerError types
+                case .communication(let error), .configuration(let error), .connection(let error), .deviceState(let error):
                     podCommsError = error as? PodCommsError
                 default:
+                    podCommsError = nil
                     break
                 }
+            } else {
+                // Check for a non PumpManagerError PodCommsError
+                podCommsError = lastError as? PodCommsError
             }
 
             // If we have an error, update the continue state depending on whether it's fatal or if the cannula insertion was started or not

--- a/Dependencies/rileylink_ios/OmniKitUI/ViewControllers/PairPodSetupViewController.swift
+++ b/Dependencies/rileylink_ios/OmniKitUI/ViewControllers/PairPodSetupViewController.swift
@@ -134,14 +134,19 @@ class PairPodSetupViewController: SetupTableViewController {
                 errorStrings = [lastError?.localizedDescription].compactMap { $0 }
             }
             
-            var podCommsError: PodCommsError? = nil
+            let podCommsError: PodCommsError?
             if let pumpManagerError = lastError as? PumpManagerError {
                 switch pumpManagerError {
-                case .communication(let error):
+                // Check for a wrapped PodCommsError in the possible PumpManagerError types
+                case .communication(let error), .configuration(let error), .connection(let error), .deviceState(let error):
                     podCommsError = error as? PodCommsError
                 default:
+                    podCommsError = nil
                     break
                 }
+            } else {
+                // Check for a non PumpManagerError PodCommsError
+                podCommsError = lastError as? PodCommsError
             }
 
             if let podCommsError = podCommsError, podCommsError.possibleWeakCommsCause {


### PR DESCRIPTION
Fix compiler error when uncommenting mock cannula insertion fault code
Rework mock cannula insertion fault code to not be within a comment
Change mock pod fault during pairing to be a more realistic fault type
Remove extra "." in OmnipodPumpManagerError.notReadyForCannulaInsertion description