### PR TITLE
Insulin curve preferences

### DIFF
--- a/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorStateModel.swift
+++ b/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorStateModel.swift
@@ -59,6 +59,24 @@ extension PreferencesEditor {
                     settable: self
                 ),
                 Field(
+                    displayName: "Use Custom Peak Time",
+                    type: .boolean(keypath: \.useCustomPeakTime),
+                    infoText: NSLocalizedString(
+                        "Defaults to false. Setting to true allows changing insulinPeakTime. Beware: Oref assumes minimal applicable insulinPeakTimes for ultra-papid (Lyumjev) & rapid-acting (Fiasp) curves of 45 and 55min respectively. Using a lower custom PeakTime will result in issues with FreeAPS-X.",
+                        comment: "Use Custom Peak Time"
+                    ),
+                    settable: self
+                ),
+                Field(
+                    displayName: "Insulin Peak Time",
+                    type: .decimal(keypath: \.insulinPeakTime),
+                    infoText: NSLocalizedString(
+                        "Time of maximum blood glucose lowering effect of insulin, in minutes. Beware: Oref assumes minimal applicable insulinPeakTimes for ultra-papid (Lyumjev) & rapid-acting (Fiasp) curves of 45 and 55min respectively. Using a lower custom PeakTime will result in issues with FreeAPS-X. ",
+                        comment: "Insulin Peak Time"
+                    ),
+                    settable: self
+                ),
+                Field(
                     displayName: "Max IOB",
                     type: .decimal(keypath: \.maxIOB),
                     infoText: NSLocalizedString(
@@ -290,23 +308,6 @@ extension PreferencesEditor {
                     infoText: NSLocalizedString(
                         "This feature, enabled by default, resets the autosens ratio to neutral when you rewind your pump, on the assumption that this corresponds to a probable site change. Autosens will begin learning sensitivity anew from the time of the rewind, which may take up to 6 hours. If you usually rewind your pump independently of site changes, you may want to consider disabling this feature.",
                         comment: "Rewind Resets Autosens"
-                    ),
-                    settable: self
-                ),
-                Field(
-                    displayName: "Use Custom Peak Time",
-                    type: .boolean(keypath: \.useCustomPeakTime),
-                    infoText: NSLocalizedString(
-                        "Defaults to false. Setting to true allows changing insulinPeakTime", comment: "Use Custom Peak Time"
-                    ),
-                    settable: self
-                ),
-                Field(
-                    displayName: "Insulin Peak Time",
-                    type: .decimal(keypath: \.insulinPeakTime),
-                    infoText: NSLocalizedString(
-                        "Time of maximum blood glucose lowering effect of insulin, in minutes",
-                        comment: "Insulin Peak Time"
                     ),
                     settable: self
                 ),


### PR DESCRIPTION
Gives a workaround (fixes #108) in form of a warning to not use a custom peak time below orefs minimal applicable insulinPeakTime for it's insulin curves.

Also reorders the parameters for insulin curves in the preference pane.