### PR TITLE
Various bolus auto resume fixes and updates

### DIFF
--- a/Dependencies/rileylink_ios/OmniKit/PumpManager/PodCommsSession.swift
+++ b/Dependencies/rileylink_ios/OmniKit/PumpManager/PodCommsSession.swift
@@ -123,7 +123,7 @@ extension PodCommsError: LocalizedError {
         case .nonceResyncFailed:
             return nil
         case .podSuspended:
-            return nil
+            return LocalizedString("Resume delivery", comment: "Recovery suggestion when pod is suspended")
         case .podFault:
             return nil
         case .commsError:


### PR DESCRIPTION
* Cancel any pod suspend alerts for auto resume on bolus
* Fix string formatting for debug error logging
* Never auto resume for an automatic bolus
* Add autoResumeOnManualBolus let variable for user control
* Add PodCommsError recoverySuggestion for podSuspended