### PR TITLE
Consistent colouring of carb entry icon and carbs (loopYellow)

### DIFF
--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -264,7 +264,7 @@ extension Home {
                                         .renderingMode(.template)
                                         .resizable()
                                         .frame(width: 24, height: 24)
-                                        .foregroundColor(.loopGreen)
+                                        .foregroundColor(.loopYellow)
                                         .padding(8)
                                     if let carbsReq = state.carbsRequired {
                                         Text(numberFormatter.string(from: carbsReq as NSNumber)!)
@@ -283,7 +283,7 @@ extension Home {
                                     .resizable()
                                     .frame(width: 24, height: 24)
                                     .padding(8)
-                            }.foregroundColor(.loopYellow)
+                            }.foregroundColor(.loopGreen)
                             Spacer()
                             Button { state.showModal(for: .bolus(waitForSuggestion: false)) }
                             label: {

--- a/FreeAPSWatch WatchKit Extension/Views/MainView.swift
+++ b/FreeAPSWatch WatchKit Extension/Views/MainView.swift
@@ -102,7 +102,7 @@ struct MainView: View {
                     Text(iobFormatter.string(from: (state.cob ?? 0) as NSNumber)! + " g")
                         .font(.caption2)
                         .scaledToFill()
-                        .foregroundColor(.loopGreen)
+                        .foregroundColor(.loopYellow)
                         .minimumScaleFactor(0.5)
                 }
 
@@ -131,7 +131,7 @@ struct MainView: View {
                     .renderingMode(.template)
                     .resizable()
                     .frame(width: 24, height: 24)
-                    .foregroundColor(.loopGreen)
+                    .foregroundColor(.loopYellow)
             }
 
             NavigationLink(isActive: $state.isTempTargetViewActive) {
@@ -143,7 +143,7 @@ struct MainView: View {
                         .renderingMode(.template)
                         .resizable()
                         .frame(width: 24, height: 24)
-                        .foregroundColor(.loopYellow)
+                        .foregroundColor(.loopGreen)
                     if let until = state.tempTargets.compactMap(\.until).first, until > Date() {
                         Text(until, style: .timer)
                             .scaledToFill()


### PR DESCRIPTION
Since carb dots and COB prediction lines are coloured in orange/yellow (loopYellow), it would perhaps be more intuitive to also have the same colour for the carb entry icon. Here, the carb entry and target icons have switched colours (orange/green):


<img width="356" alt="Screenshot 2021-12-14 at 13 44 29" src="https://user-images.githubusercontent.com/63544115/146001001-a940aeb7-02bc-4fbd-acd2-84a6c8654b54.png">

