### PR TITLE
Reduce delta decimal fraction digits from 2 to 1

### DIFF
--- a/FreeAPS/Sources/Modules/Home/View/Header/CurrentGlucoseView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Header/CurrentGlucoseView.swift
@@ -21,7 +21,7 @@ struct CurrentGlucoseView: View {
     private var deltaFormatter: NumberFormatter {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        formatter.maximumFractionDigits = 2
+        formatter.maximumFractionDigits = 1
         formatter.positivePrefix = "+"
         return formatter
     }

--- a/FreeAPS/Sources/Services/Calendar/CalendarManager.swift
+++ b/FreeAPS/Sources/Services/Calendar/CalendarManager.swift
@@ -128,7 +128,7 @@ final class BaseCalendarManager: CalendarManager, Injectable {
     private var deltaFormatter: NumberFormatter {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        formatter.maximumFractionDigits = 2
+        formatter.maximumFractionDigits = 1
         formatter.positivePrefix = "+"
         return formatter
     }

--- a/FreeAPS/Sources/Services/UserNotifiactions/UserNotificationsManager.swift
+++ b/FreeAPS/Sources/Services/UserNotifiactions/UserNotificationsManager.swift
@@ -343,7 +343,7 @@ final class BaseUserNotificationsManager: NSObject, UserNotificationsManager, In
     private var deltaFormatter: NumberFormatter {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        formatter.maximumFractionDigits = 2
+        formatter.maximumFractionDigits = 1
         formatter.positivePrefix = "+"
         return formatter
     }

--- a/FreeAPS/Sources/Services/WatchManager/WatchManager.swift
+++ b/FreeAPS/Sources/Services/WatchManager/WatchManager.swift
@@ -172,7 +172,7 @@ final class BaseWatchManager: NSObject, WatchManager, Injectable {
     private var deltaFormatter: NumberFormatter {
         let formatter = NumberFormatter()
         formatter.numberStyle = .decimal
-        formatter.maximumFractionDigits = 2
+        formatter.maximumFractionDigits = 1
         formatter.positivePrefix = "+"
         return formatter
     }


### PR DESCRIPTION
With mmol/L units, two decimal places is redundant, and different from how Nightscout etc display delta. Reducing to one decimal place make the delta value more readable, and may allow for larger fonts (adjusting from font size 12 to 14 seems to work well on both the small original SE and on 13 mini, not shown here)

This commit changes the app, watch app, notifications and calendar entries.

I have only checked the in-app display and notifications so far. 

<img width="369" alt="Screenshot 2021-12-14 at 13 53 24" src="https://user-images.githubusercontent.com/63544115/146002440-49d93206-ebc7-4a38-9799-d652c499e900.png">

