### PR TITLE
Only upload status to Nightscout during open loop

### DIFF
--- a/FreeAPS/Sources/APS/APSManager.swift
+++ b/FreeAPS/Sources/APS/APSManager.swift
@@ -160,10 +160,10 @@ final class BaseAPSManager: APSManager, Injectable {
                 guard let self = self else { return }
 
                 if ok {
-                    self.nightscout.uploadStatus()
                     if self.settings.closedLoop {
                         self.enactSuggested()
                     } else {
+                        self.nightscout.uploadStatus()
                         self.isLooping.send(false)
                         self.lastLoopDate = Date()
                     }


### PR DESCRIPTION
Hi,

We've started trying out FreeAPS last Friday. So far it's been amazing. Thanks for the effort in building this! 👍 

I noticed that in Nightscout we had 2 device status records for every loop, one enacted and one not. This caused the prediction lines and the pill to randomly disappear. I started tracing the code and found that self.enactSuggested() already does an upload. So I've moved the Nightscout.uploadStatus to the open loop section. 

This doesn't completely fix the predictions disappearing, they now only show when the loop is enacted, but I think this is a nightscout problem. I'm looking into that as well. Someone using AndroidAPS mentioned that it happens there too. At least the device status records are populated correctly in Mongo. 

My experience with the codebase is obviously very limited since I only started tinkering 2 days ago. So if this is not the right location to fix this, let me know and I'll try to fix it/help. 