### PR TITLE
Fixed display of nested temporary targets

### DIFF
--- a/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/Chart/MainChartView.swift
@@ -43,6 +43,7 @@ struct MainChartView: View {
     @Binding var autotunedBasalProfile: [BasalProfileEntry]
     @Binding var basalProfile: [BasalProfileEntry]
     @Binding var tempTargets: [TempTarget]
+    @Binding var displayedTempTargets: [TempTarget]
     @Binding var carbs: [CarbsEntry]
     @Binding var timerDate: Date
     @Binding var units: GlucoseUnits
@@ -613,7 +614,7 @@ extension MainChartView {
 
     private func calculateTempTargetsRects(fullSize: CGSize) {
         calculationQueue.async {
-            var rects = tempTargets.map { tempTarget -> CGRect in
+            var rects = displayedTempTargets.map { tempTarget -> CGRect in
                 let x0 = timeToXCoordinate(tempTarget.createdAt.timeIntervalSince1970, fullSize: fullSize)
                 let y0 = glucoseToYCoordinate(Int(tempTarget.targetTop ?? 0), fullSize: fullSize)
                 let x1 = timeToXCoordinate(

--- a/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
+++ b/FreeAPS/Sources/Modules/Home/View/HomeRootView.swift
@@ -269,6 +269,7 @@ extension Home {
                     autotunedBasalProfile: $state.autotunedBasalProfile,
                     basalProfile: $state.basalProfile,
                     tempTargets: $state.tempTargets,
+                    displayedTempTargets: $state.displayedTempTargets,
                     carbs: $state.carbs,
                     timerDate: $state.timerDate,
                     units: $state.units


### PR DESCRIPTION
The project has bug with display temporary targets (TT), which overlapping each other. If one TT start on time N, finish on time M, and other TT place in range `(N,M)`, where it start > N, and finish < M, then second part of first TT doesn't display.

Fix improve bug.
You can use this temptargets.json for tests (pls change dates)

```
[
  {
    "_id" : "6286F30D-0E83-4688-9E18-62DB1DD0EE13",
    "name" : "Temp target",
    "reason" : "Temp target",
    "created_at" : "2022-01-12T08:05:00.000Z",
    "targetTop" : 117.117117117117095508481454427404360236,
    "duration" : 30,
    "enteredBy" : "freeaps-x",
    "targetBottom" : 117.117117117117095508481454427404360236
  },
  {
    "_id" : "5F198783-3158-4C53-B609-E527DA7B6859",
    "name" : "😌 Normal",
    "reason" : "😌 Normal",
    "created_at" : "2022-01-12T06:25:45.276Z",
    "targetTop" : 99.099099099099080814868922977034458662,
    "duration" : 120,
    "enteredBy" : "freeaps-x",
    "targetBottom" : 90.099099099099080814868922977034458662
  },
  {
    "_id" : "A652AD85-F433-4F31-BEE9-255CCB75286A",
    "name" : "Temp target",
    "reason" : "Temp target",
    "created_at" : "2022-01-12T05:30:00.000Z",
    "targetTop" : 144.144144144144117548900251602959212599,
    "duration" : 320,
    "enteredBy" : "freeaps-x",
    "targetBottom" : 108.108108108108088161675188702219409449
  },
  {
    "_id" : "B8E90922-069D-4DF3-BF52-A8E5DD8B5C5C",
    "name" : "Temp target",
    "reason" : "Temp target",
    "created_at" : "2022-01-12T05:02:00.000Z",
    "targetTop" : 90.090090090090073468062657251849507874,
    "duration" : 15,
    "enteredBy" : "freeaps-x",
    "targetBottom" : 72.072072072072058774450125801479606299
  },
  {
    "_id" : "5F198783-3158-4C53-B609-E527DA7B6859",
    "name" : "😌 Normal",
    "reason" : "😌 Normal",
    "created_at" : "2022-01-12T03:42:08.661Z",
    "targetTop" : 99.099099099099080814868922977034458662,
    "duration" : 120,
    "enteredBy" : "freeaps-x",
    "targetBottom" : 99.099099099099080814868922977034458662
  },
  {
    "_id" : "CF99D482-06D2-4EE3-9F50-37E2A5A9A611",
    "name" : "🍓Eating soon",
    "reason" : "🍓Eating soon",
    "created_at" : "2022-01-12T03:07:37.904Z",
    "targetTop" : 81.081081081081066121256391526664557087,
    "duration" : 60,
    "enteredBy" : "freeaps-x",
    "targetBottom" : 81.081081081081066121256391526664557087
  }
]
```