### PR TITLE
Add the ability to automatically store the current profile on Nightscout

### DIFF
--- a/FreeAPS/Sources/APS/OpenAPS/Constants.swift
+++ b/FreeAPS/Sources/APS/OpenAPS/Constants.swift
@@ -77,6 +77,7 @@ extension OpenAPS {
         static let uploadedCarbs = "upload/uploaded-carbs.json"
         static let uploadedTempTargets = "upload/uploaded-temptargets.json"
         static let uploadedGlucose = "upload/uploaded-glucose.json"
+        static let uploadedProfile = "upload/uploaded-profile.json"
     }
 
     enum FreeAPS {

--- a/FreeAPS/Sources/Models/NightscoutStatus.swift
+++ b/FreeAPS/Sources/Models/NightscoutStatus.swift
@@ -43,6 +43,7 @@ struct ScheduledNightscoutProfile: JSON {
     let sens: [NightscoutTimevalue]
     let basal: [NightscoutTimevalue]
     let carbratio: [NightscoutTimevalue]
+    let units: String
 }
 
 struct NightscoutProfileStore: JSON {

--- a/FreeAPS/Sources/Models/NightscoutStatus.swift
+++ b/FreeAPS/Sources/Models/NightscoutStatus.swift
@@ -35,7 +35,7 @@ struct NightscoutTimevalue: JSON {
 
 struct ScheduledNightscoutProfile: JSON {
     let dia: Decimal
-    let carbs_hr: Decimal
+    let carbs_hr: Int
     let delay: Decimal
     let timezone: String
     let target_low: [NightscoutTimevalue]

--- a/FreeAPS/Sources/Models/NightscoutStatus.swift
+++ b/FreeAPS/Sources/Models/NightscoutStatus.swift
@@ -26,3 +26,33 @@ struct Uploader: JSON {
     let batteryVoltage: Decimal?
     let battery: Int
 }
+
+struct NightscoutTimevalue: JSON {
+    // rep["time"] = String(format:"%02i:%02i", Int(hours), Int(minutes))
+    // rep["value"] = value
+    //  rep["timeAsSeconds"] = Int(offset)
+    let time: String
+    let value: Decimal
+    let timeAsSeconds: Int
+}
+
+struct ScheduledNightscoutProfile: JSON {
+    let dia: Decimal
+    let carbs_hr: Decimal
+    let delay: Decimal
+    let timezone: String
+    let target_low: [NightscoutTimevalue]
+    let target_high: [NightscoutTimevalue]
+    let sens: [NightscoutTimevalue]
+    let basal: [NightscoutTimevalue]
+    let carbratio: [NightscoutTimevalue]
+}
+
+struct NightscoutProfileStore: JSON {
+    let defaultProfile: String
+    let startDate: Date
+    let mills: Int
+    let units: String
+    let enteredBy: String
+    let store: [String: ScheduledNightscoutProfile]
+}

--- a/FreeAPS/Sources/Models/NightscoutStatus.swift
+++ b/FreeAPS/Sources/Models/NightscoutStatus.swift
@@ -28,9 +28,6 @@ struct Uploader: JSON {
 }
 
 struct NightscoutTimevalue: JSON {
-    // rep["time"] = String(format:"%02i:%02i", Int(hours), Int(minutes))
-    // rep["value"] = value
-    //  rep["timeAsSeconds"] = Int(offset)
     let time: String
     let value: Decimal
     let timeAsSeconds: Int

--- a/FreeAPS/Sources/Modules/Settings/SettingsStateModel.swift
+++ b/FreeAPS/Sources/Modules/Settings/SettingsStateModel.swift
@@ -4,6 +4,7 @@ extension Settings {
     final class StateModel: BaseStateModel<Provider> {
         @Injected() private var broadcaster: Broadcaster!
         @Injected() private var fileManager: FileManager!
+        @Injected() private var nightscoutManager: NightscoutManager!
 
         @Published var closedLoop = false
         @Published var debugOptions = false
@@ -34,6 +35,16 @@ extension Settings {
             }
 
             return items
+        }
+
+        func uploadProfile() {
+            NSLog("SettingsState Upload Profile")
+            nightscoutManager.uploadProfile()
+        }
+
+        func hideSettingsModal() {
+            nightscoutManager.uploadProfile()
+            hideModal()
         }
     }
 }

--- a/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
+++ b/FreeAPS/Sources/Modules/Settings/View/SettingsRootView.swift
@@ -41,6 +41,13 @@ extension Settings {
                     Toggle("Debug options", isOn: $state.debugOptions)
                     if state.debugOptions {
                         Group {
+                            Text("NS Upload Profile").onTapGesture {
+                                state.uploadProfile()
+                            }
+                            Text("NS Uploaded Profile")
+                                .navigationLink(to: .configEditor(file: OpenAPS.Nightscout.uploadedProfile), from: self)
+                        }
+                        Group {
                             Text("Preferences")
                                 .navigationLink(to: .configEditor(file: OpenAPS.Settings.preferences), from: self)
                             Text("Pump Settings")
@@ -117,7 +124,7 @@ extension Settings {
             }
             .onAppear(perform: configureView)
             .navigationTitle("Settings")
-            .navigationBarItems(leading: Button("Close", action: state.hideModal))
+            .navigationBarItems(leading: Button("Close", action: state.hideSettingsModal))
             .navigationBarTitleDisplayMode(.automatic)
         }
     }

--- a/FreeAPS/Sources/Services/Network/NightscoutAPI.swift
+++ b/FreeAPS/Sources/Services/Network/NightscoutAPI.swift
@@ -13,6 +13,7 @@ class NightscoutAPI {
         static let uploadEntriesPath = "/api/v1/entries.json"
         static let treatmentsPath = "/api/v1/treatments.json"
         static let statusPath = "/api/v1/devicestatus.json"
+        static let profilePath = "/api/v1/profile.json"
         static let retryCount = 1
         static let timeout: TimeInterval = 60
     }
@@ -308,6 +309,30 @@ extension NightscoutAPI {
             request.addValue(secret.sha1(), forHTTPHeaderField: "api-secret")
         }
         request.httpBody = try! JSONCoding.encoder.encode(status)
+        request.httpMethod = "POST"
+
+        return service.run(request)
+            .retry(Config.retryCount)
+            .map { _ in () }
+            .eraseToAnyPublisher()
+    }
+
+    func uploadProfile(_ profile: NightscoutProfileStore) -> AnyPublisher<Void, Swift.Error> {
+        var components = URLComponents()
+        components.scheme = url.scheme
+        components.host = url.host
+        components.port = url.port
+        components.path = Config.profilePath
+
+        var request = URLRequest(url: components.url!)
+        request.allowsConstrainedNetworkAccess = false
+        request.timeoutInterval = Config.timeout
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        if let secret = secret {
+            request.addValue(secret.sha1(), forHTTPHeaderField: "api-secret")
+        }
+        request.httpBody = try! JSONCoding.encoder.encode(profile)
         request.httpMethod = "POST"
 
         return service.run(request)

--- a/FreeAPS/Sources/Services/Network/NightscoutManager.swift
+++ b/FreeAPS/Sources/Services/Network/NightscoutManager.swift
@@ -309,7 +309,6 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
             enteredBy: NigtscoutTreatment.local,
             store: [defaultProfile: ps]
         )
-        NSLog(p.rawJSON)
 
         if let uploadedProfile = storage.retrieve(OpenAPS.Nightscout.uploadedProfile, as: NightscoutProfileStore.self),
            (uploadedProfile.store[defaultProfile]?.rawJSON ?? "") == ps.rawJSON

--- a/FreeAPS/Sources/Services/Network/NightscoutManager.swift
+++ b/FreeAPS/Sources/Services/Network/NightscoutManager.swift
@@ -297,7 +297,8 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
             target_high: target_high,
             sens: sens,
             basal: basal,
-            carbratio: cr
+            carbratio: cr,
+            units: settingsManager.settings.units.rawValue.lowercased()
         )
         let defaultProfile = "default"
         let now = Date()
@@ -305,7 +306,7 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
             defaultProfile: defaultProfile,
             startDate: now,
             mills: Int(now.timeIntervalSince1970),
-            units: String(describing: settingsManager.settings.units),
+            units: settingsManager.settings.units.rawValue.lowercased(),
             enteredBy: NigtscoutTreatment.local,
             store: [defaultProfile: ps]
         )

--- a/FreeAPS/Sources/Services/Network/NightscoutManager.swift
+++ b/FreeAPS/Sources/Services/Network/NightscoutManager.swift
@@ -295,9 +295,17 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
             nsUnits = "mmol"
         }
 
+        var carbs_hr: Decimal?
+        if let isf = sensitivities.sensitivities.map(\.sensitivity).first,
+           let cr = carbRatios.schedule.map(\.ratio).first,
+           isf > 0, cr > 0
+        {
+            // CarbImpact -> Carbs/hr = CI [mg/dl/5min] * 12 / ISF [mg/dl/U] * CR [g/U]
+            carbs_hr = settingsManager.preferences.min5mCarbimpact * 12 / isf * cr
+        }
         let ps = ScheduledNightscoutProfile(
             dia: settingsManager.pumpSettings.insulinActionCurve,
-            carbs_hr: settingsManager.preferences.min5mCarbimpact * 12,
+            carbs_hr: carbs_hr ?? 0,
             delay: 0,
             timezone: TimeZone.current.identifier,
             target_low: target_low,

--- a/FreeAPS/Sources/Services/Network/NightscoutManager.swift
+++ b/FreeAPS/Sources/Services/Network/NightscoutManager.swift
@@ -212,7 +212,7 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
         let uploader = Uploader(batteryVoltage: nil, battery: Int(device.batteryLevel * 100))
 
         let status = NightscoutStatus(
-            device: NigtscoutTreatment.local,
+            device: "freeaps-x://" + device.name,
             openaps: openapsStatus,
             pump: pump,
             preferences: preferences,
@@ -317,7 +317,7 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
             return
         }
         guard let nightscout = nightscoutAPI, isNetworkReachable, isUploadEnabled else {
-            return // Just([]).eraseToAnyPublisher()
+            return
         }
         processQueue.async {
             nightscout.uploadProfile(p)

--- a/FreeAPS/Sources/Services/Network/NightscoutManager.swift
+++ b/FreeAPS/Sources/Services/Network/NightscoutManager.swift
@@ -310,7 +310,7 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
         }
         let ps = ScheduledNightscoutProfile(
             dia: settingsManager.pumpSettings.insulinActionCurve,
-            carbs_hr: carbs_hr,
+            carbs_hr: Int(carbs_hr),
             delay: 0,
             timezone: TimeZone.current.identifier,
             target_low: target_low,

--- a/FreeAPS/Sources/Services/Network/NightscoutManager.swift
+++ b/FreeAPS/Sources/Services/Network/NightscoutManager.swift
@@ -312,7 +312,7 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
         let p = NightscoutProfileStore(
             defaultProfile: defaultProfile,
             startDate: now,
-            mills: Int(now.timeIntervalSince1970),
+            mills: Int(now.timeIntervalSince1970) * 1000,
             units: nsUnits,
             enteredBy: NigtscoutTreatment.local,
             store: [defaultProfile: ps]

--- a/FreeAPS/Sources/Services/Network/NightscoutManager.swift
+++ b/FreeAPS/Sources/Services/Network/NightscoutManager.swift
@@ -287,6 +287,13 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
                 timeAsSeconds: item.minutes * 60
             )
         }
+        var nsUnits = ""
+        switch settingsManager.settings.units {
+        case .mgdL:
+            nsUnits = "mg/dl"
+        case .mmolL:
+            nsUnits = "mmol"
+        }
 
         let ps = ScheduledNightscoutProfile(
             dia: settingsManager.pumpSettings.insulinActionCurve,
@@ -298,7 +305,7 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
             sens: sens,
             basal: basal,
             carbratio: cr,
-            units: settingsManager.settings.units.rawValue.lowercased()
+            units: nsUnits
         )
         let defaultProfile = "default"
         let now = Date()
@@ -306,7 +313,7 @@ final class BaseNightscoutManager: NightscoutManager, Injectable {
             defaultProfile: defaultProfile,
             startDate: now,
             mills: Int(now.timeIntervalSince1970),
-            units: settingsManager.settings.units.rawValue.lowercased(),
+            units: nsUnits,
             enteredBy: NigtscoutTreatment.local,
             store: [defaultProfile: ps]
         )


### PR DESCRIPTION
This helps keeping track of settings changes and in particular to keep the basal rates in Nightscout in sync with the app. To avoid too many writes, it onlys sync the data on exiting the settings screen.  It won't track autotune changes, but that would be relatively easy to upload as well. I'd be a bit concerned though about too many profiles being created in Nightscout. 

I have another patch which allows copying Autotune numbers to the pump, which would help that scenario (see master branch in my fork).