### PR TITLE
Allow insulin delivery until empty pod reservoir

### DIFF
--- a/FreeAPS/Sources/APS/APSManager.swift
+++ b/FreeAPS/Sources/APS/APSManager.swift
@@ -215,7 +215,7 @@ final class BaseAPSManager: APSManager, Injectable {
         }
 
         let reservoir = storage.retrieve(OpenAPS.Monitor.reservoir, as: Decimal.self) ?? 100
-        guard reservoir > 0 else {
+        guard reservoir >= 0 else {
             return APSError.invalidPumpState(message: "Reservoir is empty")
         }
 


### PR DESCRIPTION
There are 4 units reserve capacity in pods. This allows insulin delivery until pod reservoir is fully empty / screaming.