### PR TITLE
New logic of "Skip bolus after carbs"

### DIFF
--- a/FreeAPS/Sources/Application/FreeAPSApp.swift
+++ b/FreeAPS/Sources/Application/FreeAPSApp.swift
@@ -49,7 +49,7 @@ import Swinject
 
     var body: some Scene {
         WindowGroup {
-            Main.RootView(resolver: resolver)
+            rootView
                 .onOpenURL(perform: handleURL)
         }
         .onChange(of: scenePhase) { newScenePhase in

--- a/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
@@ -70,6 +70,18 @@
 /* Add carbs header and button in Watch app. You can skip the last " " space. It's just for differentiation */
 "Add Carbs " = "Add Carbs ";
 
+/* Fast Add carbs button */
+"Fast Add" = "Fast Add";
+
+/* Fast Add carbs button description */
+"Carbs will add and FreeAPX X will determine and inject bolus without your participation" = "Carbs will add and FreeAPX X will determine and inject bolus without your participation";
+
+/* Simple Add carbs button */
+"Simple Add" = "Simple Add";
+
+/* Simple Add carbs button description*/
+"Carbs will add without bolus" = "Carbs will add without bolus";
+
 /*  */
 "Amount Carbs" = "Amount Carbs";
 

--- a/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
@@ -74,7 +74,7 @@
 "Fast Add" = "Fast Add";
 
 /* Fast Add carbs button description */
-"Carbs will add and FreeAPX X will determine and inject bolus without your participation" = "Carbs will add and FreeAPX X will determine and inject bolus without your participation";
+"Carbs will add and FreeAPX X will update forecasts without bolus" = "Carbs will add and FreeAPX X will update forecasts without bolus";
 
 /* Simple Add carbs button */
 "Simple Add" = "Simple Add";

--- a/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/en.lproj/Localizable.strings
@@ -66,9 +66,11 @@
 
 /* Add carbs screen */
 "Add Carbs" = "Add Carbs";
+"Add without bolus" = "Add without bolus";
 
 /* Add carbs header and button in Watch app. You can skip the last " " space. It's just for differentiation */
 "Add Carbs " = "Add Carbs ";
+"Without bolus" = "Without bolus";
 
 /*  */
 "Amount Carbs" = "Amount Carbs";

--- a/FreeAPS/Sources/Localizations/Main/ru.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/ru.lproj/Localizable.strings
@@ -74,7 +74,7 @@
 "Fast Add" = "Добавить быстро";
 
 /* Fast Add carbs button description */
-"Carbs will add and FreeAPX X will determine and inject bolus without your participation" = "Углеводы будут добавлены, а FreeAPS X автоматически определит и введет необходимую дозу инсулина";
+"Carbs will add and FreeAPX X will update forecasts without bolus" = "Углеводы будут добавлены без ввода болюса, FreeAPS X автоматически обновит прогнозы";
 
 /* Simple Add carbs button */
 "Simple Add" = "Просто добавить";

--- a/FreeAPS/Sources/Localizations/Main/ru.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/ru.lproj/Localizable.strings
@@ -66,9 +66,11 @@
 
 /* Add carbs screen */
 "Add Carbs" = "Ввод углеводов";
+"Add without bolus" = "Ввод без болюса";
 
 /* Add carbs header and button in Watch app. You can skip the last " " space. It's just for differentiation */
 "Add Carbs " = "Ввод углеводов";
+"Without bolus" = "Без болюса";
 
 /*  */
 "Amount Carbs" = "Кол-во углеводов";

--- a/FreeAPS/Sources/Localizations/Main/ru.lproj/Localizable.strings
+++ b/FreeAPS/Sources/Localizations/Main/ru.lproj/Localizable.strings
@@ -70,6 +70,18 @@
 /* Add carbs header and button in Watch app. You can skip the last " " space. It's just for differentiation */
 "Add Carbs " = "Ввод углеводов";
 
+/* Fast Add carbs button */
+"Fast Add" = "Добавить быстро";
+
+/* Fast Add carbs button description */
+"Carbs will add and FreeAPX X will determine and inject bolus without your participation" = "Углеводы будут добавлены, а FreeAPS X автоматически определит и введет необходимую дозу инсулина";
+
+/* Simple Add carbs button */
+"Simple Add" = "Просто добавить";
+
+/* Simple Add carbs button description*/
+"Carbs will add without bolus" = "Углеводы будут добавлены без ввода болюса";
+
 /*  */
 "Amount Carbs" = "Кол-во углеводов";
 

--- a/FreeAPS/Sources/Models/FreeAPSSettings.swift
+++ b/FreeAPS/Sources/Models/FreeAPSSettings.swift
@@ -10,7 +10,6 @@ struct FreeAPSSettings: JSON, Equatable {
     var localGlucosePort: Int = 8080
     var debugOptions: Bool = false
     var insulinReqFraction: Decimal = 0.7
-    var skipBolusScreenAfterCarbs: Bool = false
     var cgm: CGMType = .nightscout
     var uploadGlucose: Bool = false
     var useCalendar: Bool = false
@@ -65,10 +64,6 @@ extension FreeAPSSettings: Decodable {
 
         if let insulinReqFraction = try? container.decode(Decimal.self, forKey: .insulinReqFraction) {
             settings.insulinReqFraction = insulinReqFraction
-        }
-
-        if let skipBolusScreenAfterCarbs = try? container.decode(Bool.self, forKey: .skipBolusScreenAfterCarbs) {
-            settings.skipBolusScreenAfterCarbs = skipBolusScreenAfterCarbs
         }
 
         if let cgm = try? container.decode(CGMType.self, forKey: .cgm) {

--- a/FreeAPS/Sources/Modules/AddCarbs/AddCarbsStateModel.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/AddCarbsStateModel.swift
@@ -22,12 +22,7 @@ extension AddCarbs {
                 CarbsEntry(createdAt: date, carbs: carbs, enteredBy: CarbsEntry.manual)
             ])
 
-            if settingsManager.settings.skipBolusScreenAfterCarbs {
-                apsManager.determineBasalSync()
-                showModal(for: nil)
-            } else {
-                showModal(for: .bolus(waitForSuggestion: true))
-            }
+            showModal(for: .bolus(waitForSuggestion: true))
         }
 
         func fastAdd() {

--- a/FreeAPS/Sources/Modules/AddCarbs/AddCarbsStateModel.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/AddCarbsStateModel.swift
@@ -29,5 +29,32 @@ extension AddCarbs {
                 showModal(for: .bolus(waitForSuggestion: true))
             }
         }
+
+        func fastAdd() {
+            guard carbs > 0 else {
+                showModal(for: nil)
+                return
+            }
+
+            carbsStorage.storeCarbs([
+                CarbsEntry(createdAt: date, carbs: carbs, enteredBy: CarbsEntry.manual)
+            ])
+
+            apsManager.determineBasalSync()
+            showModal(for: nil)
+        }
+
+        func addWithoutbolus() {
+            guard carbs > 0 else {
+                showModal(for: nil)
+                return
+            }
+
+            carbsStorage.storeCarbs([
+                CarbsEntry(createdAt: date, carbs: carbs, enteredBy: CarbsEntry.manual)
+            ])
+
+            showModal(for: nil)
+        }
     }
 }

--- a/FreeAPS/Sources/Modules/AddCarbs/AddCarbsStateModel.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/AddCarbsStateModel.swift
@@ -12,7 +12,7 @@ extension AddCarbs {
             carbsRequired = provider.suggestion?.carbsReq
         }
 
-        func add() {
+        func addCarbs() {
             guard carbs > 0 else {
                 showModal(for: nil)
                 return
@@ -22,12 +22,21 @@ extension AddCarbs {
                 CarbsEntry(createdAt: date, carbs: carbs, enteredBy: CarbsEntry.manual)
             ])
 
-            if settingsManager.settings.skipBolusScreenAfterCarbs {
-                apsManager.determineBasalSync()
+            showModal(for: .bolus(waitForSuggestion: true))
+        }
+
+        func addCarbsWitoutBolus() {
+            guard carbs > 0 else {
                 showModal(for: nil)
-            } else {
-                showModal(for: .bolus(waitForSuggestion: true))
+                return
             }
+
+            carbsStorage.storeCarbs([
+                CarbsEntry(createdAt: date, carbs: carbs, enteredBy: CarbsEntry.manual)
+            ])
+
+            apsManager.determineBasalSync()
+            showModal(for: nil)
         }
     }
 }

--- a/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
@@ -35,8 +35,11 @@ extension AddCarbs {
                 }
 
                 Section {
-                    Button { state.add() }
+                    Button { state.addCarbs() }
                     label: { Text("Add") }
+                        .disabled(state.carbs <= 0)
+                    Button { state.addCarbsWitoutBolus() }
+                    label: { Text("Add witout bolus") }
                         .disabled(state.carbs <= 0)
                 }
             }

--- a/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
@@ -39,7 +39,7 @@ extension AddCarbs {
                     label: { Text("Add") }
                         .disabled(state.carbs <= 0)
                     VStack(alignment: .leading, spacing: 5) {
-                        Button { state.fastAdd()() }
+                        Button { state.fastAdd() }
                         label: { Text("Fast Add") }
                             .disabled(state.carbs <= 0)
                         Text(

--- a/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
@@ -43,7 +43,7 @@ extension AddCarbs {
                         label: { Text("Fast Add") }
                             .disabled(state.carbs <= 0)
                         Text(
-                            "Carbs will add and FreeAPX X will determine and inject bolus without your participation"
+                            "Carbs will add and FreeAPX X will update forecasts without bolus"
                         )
                         .font(.caption)
                         .foregroundColor(Color.secondary)

--- a/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
@@ -39,7 +39,7 @@ extension AddCarbs {
                     label: { Text("Add") }
                         .disabled(state.carbs <= 0)
                     Button { state.addCarbsWitoutBolus() }
-                    label: { Text("Add witout bolus") }
+                    label: { Text("Add without bolus") }
                         .disabled(state.carbs <= 0)
                 }
             }

--- a/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
@@ -35,9 +35,31 @@ extension AddCarbs {
                 }
 
                 Section {
-                    Button { state.add() }
+                    Button { state.fastAdd() }
                     label: { Text("Add") }
                         .disabled(state.carbs <= 0)
+                    VStack(alignment: .leading, spacing: 5) {
+                        Button { state.addWithoutbolus() }
+                        label: { Text("Fast Add") }
+                            .disabled(state.carbs <= 0)
+                        Text(
+                            "Carbs will add and FreeAPX X will determine and inject bolus without your participation"
+                        )
+                        .font(.caption)
+                        .foregroundColor(Color.secondary)
+                    }
+                    .padding(.top, 5)
+                    VStack(alignment: .leading, spacing: 5) {
+                        Button { state.addWithoutbolus() }
+                        label: { Text("Simple Add") }
+                            .disabled(state.carbs <= 0)
+                        Text(
+                            "Carbs will add without bolus"
+                        )
+                        .font(.caption)
+                        .foregroundColor(Color.secondary)
+                    }
+                    .padding(.top, 5)
                 }
             }
             .onAppear(perform: configureView)

--- a/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
+++ b/FreeAPS/Sources/Modules/AddCarbs/View/AddCarbsRootView.swift
@@ -35,11 +35,11 @@ extension AddCarbs {
                 }
 
                 Section {
-                    Button { state.fastAdd() }
+                    Button { state.add() }
                     label: { Text("Add") }
                         .disabled(state.carbs <= 0)
                     VStack(alignment: .leading, spacing: 5) {
-                        Button { state.addWithoutbolus() }
+                        Button { state.fastAdd()() }
                         label: { Text("Fast Add") }
                             .disabled(state.carbs <= 0)
                         Text(

--- a/FreeAPS/Sources/Modules/Migration/MigrationStateModel.swift
+++ b/FreeAPS/Sources/Modules/Migration/MigrationStateModel.swift
@@ -14,6 +14,7 @@ extension Migration {
             Publishers
                 .getMigrationPublisher(fromMigrationManager: manager)
 //                .migrate(startAtVersion: "0.2.6", MigrationWorkExample())
+                .migrate(startAtVersion: "0.2.6", MigrationWorkCarbsWithoutBolus())
                 .sink { _ in
                     debug(.businessLogic, "Migration did finish")
                     // fake pause

--- a/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorStateModel.swift
+++ b/FreeAPS/Sources/Modules/PreferencesEditor/PreferencesEditorStateModel.swift
@@ -15,7 +15,6 @@ extension PreferencesEditor {
 
             subscribeSetting(\.allowAnnouncements, on: $allowAnnouncements) { allowAnnouncements = $0 }
             subscribeSetting(\.insulinReqFraction, on: $insulinReqFraction) { insulinReqFraction = $0 }
-            subscribeSetting(\.skipBolusScreenAfterCarbs, on: $skipBolusScreenAfterCarbs) { skipBolusScreenAfterCarbs = $0 }
 
             subscribeSetting(\.units, on: $unitsIndex.map { $0 == 0 ? GlucoseUnits.mgdL : .mmolL }) {
                 unitsIndex = $0 == .mgdL ? 0 : 1

--- a/FreeAPS/Sources/Modules/PreferencesEditor/View/PreferencesEditorRootView.swift
+++ b/FreeAPS/Sources/Modules/PreferencesEditor/View/PreferencesEditorRootView.swift
@@ -34,8 +34,6 @@ extension PreferencesEditor {
                         Text("Recommended Insulin Fraction")
                         DecimalTextField("", value: $state.insulinReqFraction, formatter: formatter)
                     }
-
-                    Toggle("Skip Bolus screen after carbs", isOn: $state.skipBolusScreenAfterCarbs)
                 }
 
                 ForEach(state.sections.indexed(), id: \.1.id) { sectionIndex, section in

--- a/FreeAPS/Sources/Services/Migration/MigrationWorkItem.swift
+++ b/FreeAPS/Sources/Services/Migration/MigrationWorkItem.swift
@@ -16,3 +16,16 @@ class MigrationWorkExample: MigrationWorkItem {
         debug(.businessLogic, "Migration MigrationWorkExample will start")
     }
 }
+
+// Remove skipBolusScreenAfterCarbs setting
+class MigrationWorkCarbsWithoutBolus: MigrationWorkItem {
+    private(set) var repeatEachTime: Bool = false
+    private(set) var uniqueIdentifier: String = "Migration.MigrationWorkCarbsWithoutBolus"
+    func migrationHandler(_: AppInfo) {
+        debug(.businessLogic, "Migration MigrationWorkCarbsWithoutBolus will start")
+        guard let settingManager = FreeAPSApp.resolver.resolve(SettingsManager.self) else { return }
+        // Just resave settings to remove not used setting
+        settingManager.settings.animatedBackground.toggle()
+        settingManager.settings.animatedBackground.toggle()
+    }
+}

--- a/FreeAPS/Sources/Services/WatchManager/WatchManager.swift
+++ b/FreeAPS/Sources/Services/WatchManager/WatchManager.swift
@@ -93,7 +93,6 @@ final class BaseWatchManager: NSObject, WatchManager, Injectable {
                         until: untilDate
                     )
                 }
-            self.state.bolusAfterCarbs = !self.settingsManager.settings.skipBolusScreenAfterCarbs
             let eBG = self.evetualBGStraing()
             self.state.eventualBG = eBG.map { "⇢ " + $0 }
             self.state.eventualBGRaw = eBG
@@ -240,18 +239,12 @@ extension BaseWatchManager: WCSessionDelegate {
                 CarbsEntry(createdAt: Date(), carbs: Decimal(carbs), enteredBy: CarbsEntry.manual)
             ])
 
-            if settingsManager.settings.skipBolusScreenAfterCarbs {
-                apsManager.determineBasalSync()
-                replyHandler(["confirmation": true])
-                return
-            } else {
-                apsManager.determineBasal()
-                    .sink { _ in
-                        replyHandler(["confirmation": true])
-                    }
-                    .store(in: &lifetime)
-                return
-            }
+            apsManager.determineBasal()
+                .sink { _ in
+                    replyHandler(["confirmation": true])
+                }
+                .store(in: &lifetime)
+            return
         }
 
         if let tempTargetID = message["tempTarget"] as? String {

--- a/FreeAPSWatch WatchKit Extension/DataFlow.swift
+++ b/FreeAPSWatch WatchKit Extension/DataFlow.swift
@@ -17,7 +17,6 @@ struct WatchState: Codable {
     var iob: Decimal?
     var cob: Decimal?
     var tempTargets: [TempTargetWatchPreset] = []
-    var bolusAfterCarbs: Bool?
     var eventualBG: String?
     var eventualBGRaw: String?
 }

--- a/FreeAPSWatch WatchKit Extension/Views/CarbsView.swift
+++ b/FreeAPSWatch WatchKit Extension/Views/CarbsView.swift
@@ -52,6 +52,7 @@ struct CarbsView: View {
                     WKInterfaceDevice.current().play(.click)
                     // Get amount from displayed string
                     let amount = Int(numberFormatter.string(from: amount as NSNumber)!) ?? Int(amount.rounded())
+                    state.bolusAfterCarbs = true
                     state.addCarbs(amount)
                 }
                 label: {
@@ -62,6 +63,24 @@ struct CarbsView: View {
                             .frame(width: 24, height: 24)
                             .foregroundColor(.loopGreen)
                         Text("Add Carbs ")
+                    }
+                }
+                .disabled(amount <= 0)
+                Button {
+                    WKInterfaceDevice.current().play(.click)
+                    // Get amount from displayed string
+                    let amount = Int(numberFormatter.string(from: amount as NSNumber)!) ?? Int(amount.rounded())
+                    state.bolusAfterCarbs = false
+                    state.addCarbs(amount)
+                }
+                label: {
+                    HStack {
+                        Image("carbs", bundle: nil)
+                            .renderingMode(.template)
+                            .resizable()
+                            .frame(width: 24, height: 24)
+                            .foregroundColor(.loopGreen)
+                        Text("Without bolus")
                     }
                 }
                 .disabled(amount <= 0)

--- a/FreeAPSWatch WatchKit Extension/WatchStateModel.swift
+++ b/FreeAPSWatch WatchKit Extension/WatchStateModel.swift
@@ -157,7 +157,6 @@ class WatchStateModel: NSObject, ObservableObject {
         iob = state.iob
         cob = state.cob
         tempTargets = state.tempTargets
-        bolusAfterCarbs = state.bolusAfterCarbs ?? true
         eventualBG = state.eventualBG ?? ""
         lastUpdate = Date()
     }


### PR DESCRIPTION
Often I want to use "add carbs" function without showing "Bolus screen". Usually I want to use it during hypoglycemia. Using of `skipBolusScreenAfterCarbs` setting on/off showing bolus screen and does not give me an operational choice. Now I use for it "Carbs screen" on Apple Health or swipe FAX bolus screen to bottom.

I propose add one new button on "Add carbs without bolus" on "Add carbs screen"

As result we can remove `skipBolusScreenAfterCarbs` setting from Preferences screen